### PR TITLE
Fix for DEFAULT_DELAY values larger than 127

### DIFF
--- a/Encoder/src/Encoder.java
+++ b/Encoder/src/Encoder.java
@@ -141,7 +141,7 @@ public class Encoder {
 
 				if (instruction[0].equals("DEFAULT_DELAY")
 						|| instruction[0].equals("DEFAULTDELAY")) {
-					defaultDelay = (byte) Integer.parseInt(instruction[1]
+					defaultDelay = Integer.parseInt(instruction[1]
 							.trim());
 				} else if (instruction[0].equals("DELAY")) {
 					int delay = Integer.parseInt(instruction[1].trim());


### PR DESCRIPTION
Default delay values larger than 127 previously got trashed when converting to a byte. Lots of scripts use DEFAULT_DELAY 200 which ends up effectively as DEFAULT_DELAY -57 when the casting is done. Since the logic only adds a delay command to the binary if it is greater than zero it gets skipped every time and no delays are entered.