### PR TITLE
Fixed crash when lines are less than two characters long

### DIFF
--- a/Encoder/src/Encoder.java
+++ b/Encoder/src/Encoder.java
@@ -127,9 +127,14 @@ public class Encoder {
 		for (int i = 0; i < instructions.length; i++) {
 			try {
 				boolean delayOverride = false;
-				String commentCheck = instructions[i].substring(0, 2);
-				if (commentCheck.equals("//"))
-					continue;
+
+                // Is this line too short for the comment check?
+                if (instructions[i].length() > 2) {
+                    // No, check to see if this is a comment
+                    String commentCheck = instructions[i].substring(0, 2);
+                    if (commentCheck.equals("//"))
+                        continue;
+                }
 
 				String instruction[] = instructions[i].split(" ", 2);
 


### PR DESCRIPTION
When lines are less than two characters long the comment check crashes.  With this patch the application throws an exception (because it doesn't support blank lines and has no one character commands) but it does access an array out of bounds.