### PR TITLE
Fix: wrong USB HID code for WINDOWS/GUI when not used as midifier

### DIFF
--- a/Encoder/src/Encoder.java
+++ b/Encoder/src/Encoder.java
@@ -351,8 +351,12 @@ public class Encoder {
                                 	} else if (instruction[0].equals("WINDOWS")
                                                 || instruction[0].equals("GUI")) {
                                         if (instruction.length == 1) {
+						// in this case the GUI-Key is pressed without an additional key
+						// this means the KEY_LEFT_GUI with modifier MODIFIERKEY_LEFT_GUI has to be sent.
+						// Sending MODIFIERKEY_LEFT_GUI (0x08) with no modifier (0x00) corresponds to
+						// a lowercase 'e'
+                                                file.add(strToByte(keyboardProps.getProperty("KEY_LEFT_GUI")));
                                                 file.add(strToByte(keyboardProps.getProperty("MODIFIERKEY_LEFT_GUI")));
-                                                file.add((byte) 0x00);
                                         } else {
                                                 file.add(strInstrToByte(instruction[1]));
                                                 file.add(strToByte(keyboardProps.getProperty("MODIFIERKEY_LEFT_GUI")));


### PR DESCRIPTION
Using "GUI" or "WINDOWS" command without an additional key is converted to key 0x08 and modifier 0x00, which corresponds to a lowercase 'e' in most keyboard layouts.
Instead key=KEY_LEFT_GUI and modifier=MODIFIERKEY_LEFT_GUI have to be sent in order to make GUI key work.